### PR TITLE
Removed most deprecation warnings by updating the APIs used

### DIFF
--- a/Source/Application/Application.mm
+++ b/Source/Application/Application.mm
@@ -229,7 +229,7 @@
         return false;
     }
     
-    if ([tabbar_ modalViewController] != nil)
+    if ([tabbar_ presentedViewController] != nil)
         return false;
     
     // Use external process status API internally.
@@ -420,7 +420,7 @@ errno == ENOTDIR \
 }
 
 - (void) stash {
-    [[UIApplication sharedApplication] setStatusBarStyle:UIStatusBarStyleBlackOpaque];
+    [[UIApplication sharedApplication] setStatusBarStyle:UIStatusBarStyleLightContent];
     UpdateExternalStatus(1);
     [self yieldToSelector:@selector(system:)
                withObject:@"/Applications/Limitless.app/runAsSuperuser /usr/libexec/cydia/free.sh"];
@@ -496,8 +496,8 @@ errno == ENOTDIR \
 
 - (void) loadData {
     _trace();
-    if ([emulated_ modalViewController] != nil)
-        [emulated_ dismissModalViewControllerAnimated:YES];
+    if ([emulated_ presentedViewController] != nil)
+		[emulated_ dismissViewControllerAnimated:true completion:nil];
     [window_ setUserInteractionEnabled:NO];
     
     [self reloadDataWithInvocation: nil];
@@ -728,11 +728,8 @@ errno == ENOTDIR \
 
 #pragma mark - View Controllers
 
-- (void) presentModalViewController:(UIViewController *)controller
-                              force:(BOOL)force {
-    UINavigationController *navigation = [[[UINavigationController alloc]
-                                           initWithRootViewController:controller]
-                                          autorelease];
+- (void) presentModalViewController:(UIViewController *)controller force:(BOOL)force {
+    UINavigationController *navigation = [[[UINavigationController alloc] initWithRootViewController:controller] autorelease];
     
     UIViewController *parent;
     if (emulated_ == nil)
@@ -746,7 +743,7 @@ errno == ENOTDIR \
     
     if ([Device isPad])
         [navigation setModalPresentationStyle:UIModalPresentationFormSheet];
-    [parent presentModalViewController:navigation animated:YES];
+    [parent presentViewController:navigation animated:YES completion:nil];
 }
 
 - (void) disemulate {
@@ -911,7 +908,7 @@ errno == ENOTDIR \
     [window_ setUserInteractionEnabled:NO];
     
     UIViewController *target(tabbar_);
-    if (UIViewController *modal = [target modalViewController])
+    if (UIViewController *modal = [target presentedViewController])
         target = modal;
     
     [hud showInView:[target view]];
@@ -1150,7 +1147,7 @@ errno == ENOTDIR \
     
     if ([Device isPad])
         [confirm_ setModalPresentationStyle:UIModalPresentationFormSheet];
-    [tabbar_ presentModalViewController:confirm_ animated:YES];
+    [tabbar_ presentViewController:confirm_ animated:YES completion:nil];
     
     return true;
 }

--- a/Source/Categories/View Controllers/UINavigationController+Cydia.mm
+++ b/Source/Categories/View Controllers/UINavigationController+Cydia.mm
@@ -32,7 +32,7 @@
     
     // on the iPad, this view controller is ALSO visible. :(
     if ([Device isPad])
-        if (UIViewController *modal = [self modalViewController])
+        if (UIViewController *modal = [self presentedViewController])
             if ([modal modalPresentationStyle] == UIModalPresentationFormSheet)
                 if (UIViewController *top = [self topViewController])
                     if (top != visible)

--- a/Source/Controllers/APT/APTManager.mm
+++ b/Source/Controllers/APT/APTManager.mm
@@ -157,7 +157,7 @@
           "deb http://apt.thebigboss.org/repofiles/cydia/ stable main\n"
           "deb http://cydia.zodttd.com/repo/cydia/ stable main\n"
           "deb http://apt.modmyi.com/ stable main\n",
-          kCFCoreFoundationVersionNumber] writeToFile:cydiaList atomically:YES];
+          kCFCoreFoundationVersionNumber] writeToFile:cydiaList atomically:YES encoding:NSUTF8StringEncoding error:nil];
     }
     
     // set executable permission on files

--- a/Source/Legacy/Cydia/LoadingView.mm
+++ b/Source/Legacy/Cydia/LoadingView.mm
@@ -36,7 +36,7 @@
         label_ = [[[UILabel alloc] init] autorelease];
         [label_ setFont:[UIFont boldSystemFontOfSize:15.0f]];
         [label_ setBackgroundColor:[UIColor clearColor]];
-        [label_ setTextColor:[UIColor viewFlipsideBackgroundColor]];
+        [label_ setTextColor:[UIColor blackColor]];
         [label_ setShadowColor:[UIColor whiteColor]];
         [label_ setShadowOffset:CGSizeMake(0, 1)];
         [label_ setText:[NSString stringWithFormat:Elision_, UCLocalize("LOADING"), nil]];
@@ -44,7 +44,7 @@
 
         CGSize viewsize = frame.size;
         CGSize spinnersize = [spinner_ bounds].size;
-        CGSize textsize = [[label_ text] sizeWithFont:[label_ font]];
+		CGSize textsize = [[label_ text] sizeWithAttributes:@{NSFontAttributeName: [label_ font]}];
         float bothwidth = spinnersize.width + textsize.width + 5.0f;
 
         CGRect containrect = {

--- a/Source/Legacy/CyteKit/ViewController.mm
+++ b/Source/Legacy/CyteKit/ViewController.mm
@@ -38,7 +38,7 @@
 }
 
 - (void) unloadData {
-    if (UIViewController *modal = [self modalViewController])
+    if (UIViewController *modal = [self presentedViewController])
         [modal unloadData];
 }
 

--- a/Source/Legacy/CyteKit/WebViewController.mm
+++ b/Source/Legacy/CyteKit/WebViewController.mm
@@ -326,7 +326,7 @@ float CYScrollViewDecelerationRateNormal;
 }
 
 - (void) mailComposeController:(MFMailComposeViewController*)controller didFinishWithResult:(MFMailComposeResult)result error:(NSError*)error {
-    [self dismissModalViewControllerAnimated:YES];
+    [self dismissViewControllerAnimated:YES completion:nil];
 }
 
 - (void) _setupMail:(MFMailComposeViewController *)controller {
@@ -341,7 +341,7 @@ float CYScrollViewDecelerationRateNormal;
 
         [self _setupMail:controller];
 
-        [self presentModalViewController:controller animated:YES];
+        [self presentViewController:controller animated:YES completion:nil];
         return;
     }
 
@@ -355,7 +355,7 @@ float CYScrollViewDecelerationRateNormal;
 - (void) _openSafariViewControllerForURL:(NSURL *)url {
     if ($SFSafariViewController != nil && ([url.scheme isEqualToString:@"http"] || [url.scheme isEqualToString:@"https"])) {
         SFSafariViewController *controller([[[$SFSafariViewController alloc] initWithURL:url] autorelease]);
-        [self presentModalViewController:controller animated:YES];
+		[self presentViewController:controller animated:YES completion:nil];
         return;
     }
 
@@ -451,7 +451,7 @@ float CYScrollViewDecelerationRateNormal;
             action:@selector(close)
         ] autorelease]];
 
-        [[self navigationController] presentModalViewController:navigation animated:YES];
+        [[self navigationController] presentViewController:navigation animated:true completion:nil];
     }
 }
 
@@ -755,7 +755,7 @@ float CYScrollViewDecelerationRateNormal;
 // }}}
 
 - (void) close {
-    [[[self navigationController] parentOrPresentingViewController] dismissModalViewControllerAnimated:YES];
+    [[[self navigationController] parentOrPresentingViewController] dismissViewControllerAnimated:YES completion:nil];
 }
 
 - (void) alertView:(UIAlertView *)alert clickedButtonAtIndex:(NSInteger)button {
@@ -840,7 +840,7 @@ float CYScrollViewDecelerationRateNormal;
         return nil;
 
     if (UINavigationController *navigation = [self navigationController])
-        if ([[navigation parentOrPresentingViewController] modalViewController] == navigation)
+        if ([[navigation parentOrPresentingViewController] presentedViewController] == navigation)
             return [[[UIBarButtonItem alloc]
                 initWithTitle:UCLocalize("CLOSE")
                 style:UIBarButtonItemStylePlain
@@ -984,8 +984,6 @@ float CYScrollViewDecelerationRateNormal;
 
     if ([webview_ respondsToSelector:@selector(setDataDetectorTypes:)])
         [webview_ setDataDetectorTypes:UIDataDetectorTypeAutomatic];
-    else
-        [webview_ setDetectsPhoneNumbers:NO];
 
     [webview_ setScalesPageToFit:YES];
 

--- a/Source/Legacy/SDURLCache/SDURLCache.m
+++ b/Source/Legacy/SDURLCache/SDURLCache.m
@@ -297,7 +297,7 @@ static NSDateFormatter* CreateDateFormatter(NSString *format)
     [self createDiskCachePath];
     @synchronized(self.diskCacheInfo)
     {
-        NSData *data = [NSPropertyListSerialization dataFromPropertyList:self.diskCacheInfo format:NSPropertyListBinaryFormat_v1_0 errorDescription:NULL];
+		NSData *data = [NSPropertyListSerialization dataWithPropertyList:self.diskCacheInfo format:NSPropertyListBinaryFormat_v1_0 options:0 error:nil];
         if (data)
         {
             [data writeToFile:[diskCachePath stringByAppendingPathComponent:kSDURLCacheInfoFileName] atomically:YES];

--- a/Source/Models/CoreGraphics/CYColor.hpp
+++ b/Source/Models/CoreGraphics/CYColor.hpp
@@ -11,7 +11,6 @@
 
 class CYColor {
 private:
-    CGColorRef color_;
     
     static CGColorRef Create_(CGColorSpaceRef space, float red, float green, float blue, float alpha) {
         CGFloat color[] = {red, green, blue, alpha};
@@ -19,6 +18,8 @@ private:
     }
     
 public:
+	CGColorRef color_;
+	
     CYColor() :
     color_(NULL)
     {

--- a/Source/UI/Packages/Installing/View Controllers/ConfirmationController.mm
+++ b/Source/UI/Packages/Installing/View Controllers/ConfirmationController.mm
@@ -47,7 +47,7 @@ bool DepSubstrate(const pkgCache::VerIterator &iterator) {
         
         [alert dismissWithClickedButtonIndex:-1 animated:YES];
     } else if ([context isEqualToString:@"unable"]) {
-        [self dismissModalViewControllerAnimated:YES];
+        [self dismissViewControllerAnimated:YES completion:nil];
         [alert dismissWithClickedButtonIndex:-1 animated:YES];
     } else {
         [super alertView:alert clickedButtonAtIndex:button];
@@ -56,7 +56,7 @@ bool DepSubstrate(const pkgCache::VerIterator &iterator) {
 
 - (void) _doContinue {
     [delegate_ cancelAndClear:NO];
-    [self dismissModalViewControllerAnimated:YES];
+    [self dismissViewControllerAnimated:YES completion:nil];
 }
 
 - (id) invokeDefaultMethodWithArguments:(NSArray *)args {
@@ -279,7 +279,7 @@ bool DepSubstrate(const pkgCache::VerIterator &iterator) {
 
 - (void) cancelButtonClicked {
     [delegate_ cancelAndClear:YES];
-    [self dismissModalViewControllerAnimated:YES];
+    [self dismissViewControllerAnimated:YES completion:nil];
 }
 
 #if !AlwaysReload

--- a/Source/UI/Packages/View Controllers/FileTable.mm
+++ b/Source/UI/Packages/View Controllers/FileTable.mm
@@ -23,10 +23,10 @@
     
     UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:reuseIdentifier];
     if (cell == nil) {
-        cell = [[[UITableViewCell alloc] initWithFrame:CGRectZero reuseIdentifier:reuseIdentifier] autorelease];
-        [cell setFont:[UIFont systemFontOfSize:16]];
+		cell = [[[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:reuseIdentifier] autorelease];
+        [[cell textLabel] setFont:[UIFont systemFontOfSize:16]];
     }
-    [cell setText:[files_ objectAtIndex:indexPath.row]];
+    [[cell textLabel] setText:[files_ objectAtIndex:indexPath.row]];
     [cell setSelectionStyle:UITableViewCellSelectionStyleNone];
     
     return cell;

--- a/Source/UI/Packages/View Controllers/InstalledController.mm
+++ b/Source/UI/Packages/View Controllers/InstalledController.mm
@@ -95,7 +95,6 @@
     if ((self = [super initWithDatabase:database title:UCLocalize("INSTALLED")]) != nil) {
         UISegmentedControl *segmented([[[UISegmentedControl alloc] initWithItems:[NSArray arrayWithObjects:UCLocalize("USER"), UCLocalize("EXPERT"), UCLocalize("RECENT"), nil]] autorelease]);
         [segmented setSelectedSegmentIndex:0];
-        [segmented setSegmentedControlStyle:UISegmentedControlStyleBar];
         [[self navigationItem] setTitleView:segmented];
         
         [segmented addTarget:self action:@selector(modeChanged:) forEvents:UIControlEventValueChanged];

--- a/Source/UI/Packages/View Controllers/PackageListController.mm
+++ b/Source/UI/Packages/View Controllers/PackageListController.mm
@@ -71,8 +71,8 @@
 - (void) keyboardWillShow:(NSNotification *)notification {
     CGRect bounds;
     CGPoint center;
-    [[[notification userInfo] objectForKey:UIKeyboardBoundsUserInfoKey] getValue:&bounds];
-    [[[notification userInfo] objectForKey:UIKeyboardCenterEndUserInfoKey] getValue:&center];
+    [[[notification userInfo] objectForKey:UIKeyboardFrameBeginUserInfoKey] getValue:&bounds];
+    [[[notification userInfo] objectForKey:UIKeyboardFrameEndUserInfoKey] getValue:&center];
     
     NSTimeInterval duration;
     UIViewAnimationCurve curve;

--- a/Source/UI/Packages/View Controllers/PackageSettingsController.mm
+++ b/Source/UI/Packages/View Controllers/PackageSettingsController.mm
@@ -110,12 +110,12 @@
     [ignoredSwitch_ addTarget:self action:@selector(onIgnored:) forEvents:UIControlEventValueChanged];
     
     subscribedCell_ = [[[UITableViewCell alloc] init] autorelease];
-    [subscribedCell_ setText:UCLocalize("SHOW_ALL_CHANGES")];
+    [[subscribedCell_ textLabel] setText:UCLocalize("SHOW_ALL_CHANGES")];
     [subscribedCell_ setAccessoryView:subscribedSwitch_];
     [subscribedCell_ setSelectionStyle:UITableViewCellSelectionStyleNone];
     
     ignoredCell_ = [[[UITableViewCell alloc] init] autorelease];
-    [ignoredCell_ setText:UCLocalize("IGNORE_UPGRADES")];
+    [[ignoredCell_ textLabel] setText:UCLocalize("IGNORE_UPGRADES")];
     [ignoredCell_ setAccessoryView:ignoredSwitch_];
     [ignoredCell_ setSelectionStyle:UITableViewCellSelectionStyleNone];
 }

--- a/Source/UI/Packages/View Controllers/SectionsController.mm
+++ b/Source/UI/Packages/View Controllers/SectionsController.mm
@@ -90,8 +90,8 @@
     
     SectionCell *cell = (SectionCell *)[tableView dequeueReusableCellWithIdentifier:reuseIdentifier];
     if (cell == nil)
-        cell = [[[SectionCell alloc] initWithFrame:CGRectZero reuseIdentifier:reuseIdentifier] autorelease];
-    
+		cell = [[[SectionCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:reuseIdentifier] autorelease];
+	
     [cell setSection:[self sectionAtIndexPath:indexPath] editing:[self isEditing]];
     
     return cell;

--- a/Source/UI/Packages/Views/Table Views/PackageCell.mm
+++ b/Source/UI/Packages/Views/Table Views/PackageCell.mm
@@ -13,8 +13,7 @@
 @implementation PackageCell
 
 - (PackageCell *) init {
-    CGRect frame(CGRectMake(0, 0, 320, 74));
-    if ((self = [super initWithFrame:frame reuseIdentifier:@"Package"]) != nil) {
+	if ((self = [super initWithStyle:UITableViewCellStyleDefault reuseIdentifier:@"Package"]) != nil) {
         UIView *content([self contentView]);
         CGRect bounds([content bounds]);
         
@@ -146,10 +145,16 @@
     
     if (highlighted && kCFCoreFoundationVersionNumber < 800)
         UISetColor(White_);
-    
-    if (!highlighted)
+	
+	NSMutableParagraphStyle *truncatingStyle = [[NSMutableParagraphStyle defaultParagraphStyle] mutableCopy];
+	[truncatingStyle setLineBreakMode:NSLineBreakByTruncatingTail];
+	
+	if (!highlighted) {
         UISetColor(commercial_ ? Purple_ : Black_);
-    [name_ drawAtPoint:CGPointMake(36, 8) forWidth:(width - (placard_ == nil ? 68 : 94)) withFont:Font18Bold_ lineBreakMode:NSLineBreakByTruncatingTail];
+		[name_ drawInRect:CGRectMake(36, 8, width - (placard_ == nil ? 68 : 94), CGFLOAT_MAX) withAttributes:@{NSFontAttributeName:Font18Bold_,NSParagraphStyleAttributeName: truncatingStyle, NSForegroundColorAttributeName: (commercial_ ? [UIColor colorWithCGColor:Purple_.color_] : [UIColor colorWithCGColor:Black_.color_])}];
+	} else {
+		[name_ drawInRect:CGRectMake(36, 8, width - (placard_ == nil ? 68 : 94), CGFLOAT_MAX) withAttributes:@{NSFontAttributeName:Font18Bold_,NSParagraphStyleAttributeName: truncatingStyle}];
+	}
     
     if (placard_ != nil)
         [placard_ drawAtPoint:CGPointMake(width - 52, 11)];
@@ -192,12 +197,18 @@
     
     if (!highlighted)
         UISetColor(commercial_ ? Purple_ : Black_);
-    [name_ drawAtPoint:CGPointMake(48, 8) forWidth:(width - (placard_ == nil ? 80 : 106)) withFont:Font18Bold_ lineBreakMode:NSLineBreakByTruncatingTail];
-    [source_ drawAtPoint:CGPointMake(58, 29) forWidth:(width - 95) withFont:Font12_ lineBreakMode:NSLineBreakByTruncatingTail];
+	
+	NSMutableParagraphStyle *truncatingStyle = [[NSMutableParagraphStyle defaultParagraphStyle] mutableCopy];
+	[truncatingStyle setLineBreakMode:NSLineBreakByTruncatingTail];
+	
+	[name_ drawInRect:CGRectMake(48, 8, (width - (placard_ == nil ? 80 : 106)), CGFLOAT_MAX) withAttributes:@{NSFontAttributeName: Font18Bold_, NSParagraphStyleAttributeName: truncatingStyle}];
+	[source_ drawInRect:CGRectMake(58, 29, (width - 29), CGFLOAT_MAX) withAttributes:@{NSFontAttributeName: Font12_, NSParagraphStyleAttributeName: truncatingStyle}];
     
-    if (!highlighted)
+	if (!highlighted) {
         UISetColor(commercial_ ? Purplish_ : Gray_);
-    [description_ drawAtPoint:CGPointMake(12, 46) forWidth:(width - 46) withFont:Font14_ lineBreakMode:NSLineBreakByTruncatingTail];
+		[description_ drawInRect:CGRectMake(12, 46, (width - 46), CGFLOAT_MAX) withAttributes:@{NSFontAttributeName: Font14_, NSParagraphStyleAttributeName: truncatingStyle, NSForegroundColorAttributeName: (commercial_ ? [UIColor colorWithCGColor:Purplish_.color_] : [UIColor colorWithCGColor:Gray_.color_])}];
+	} else
+		[description_ drawInRect:CGRectMake(12, 46, (width - 46), CGFLOAT_MAX) withAttributes:@{NSFontAttributeName: Font14_, NSParagraphStyleAttributeName: truncatingStyle}];
     
     if (placard_ != nil)
         [placard_ drawAtPoint:CGPointMake(width - 52, 9)];

--- a/Source/UI/Packages/Views/Table Views/SectionCell.mm
+++ b/Source/UI/Packages/Views/Table Views/SectionCell.mm
@@ -97,15 +97,27 @@
     if (editing_)
         width -= 9 + [switch_ frame].size.width;
     
-    if (!highlighted)
+	if (!highlighted) {
         UISetColor(Black_);
-    [name_ drawAtPoint:CGPointMake(48, 12) forWidth:(width - 58) withFont:Font18_ lineBreakMode:NSLineBreakByTruncatingTail];
+		
+		NSMutableParagraphStyle *truncatingStyle = [[NSMutableParagraphStyle defaultParagraphStyle] mutableCopy];
+		[truncatingStyle setLineBreakMode:NSLineBreakByTruncatingTail];
+		
+		[name_ drawInRect:CGRectMake(48, 12, width-58, CGFLOAT_MAX) withAttributes:@{NSFontAttributeName: Font18Bold_, NSForegroundColorAttributeName:[UIColor colorWithCGColor:Black_.color_], NSParagraphStyleAttributeName: truncatingStyle}];
+	} else {
+		
+		NSMutableParagraphStyle *truncatingStyle = [[NSMutableParagraphStyle defaultParagraphStyle] mutableCopy];
+		[truncatingStyle setLineBreakMode:NSLineBreakByTruncatingTail];
+		
+		[name_ drawInRect:CGRectMake(48, 12, width-58, CGFLOAT_MAX) withAttributes:@{NSFontAttributeName: Font18Bold_, NSParagraphStyleAttributeName: truncatingStyle}];
+	}
+	
     
-    CGSize size = [count_ sizeWithFont:Font14_];
+	CGSize size = [count_ sizeWithAttributes:@{NSFontAttributeName: Font14_}];
     
     UISetColor(Folder_);
     if (count_ != nil)
-        [count_ drawAtPoint:CGPointMake(Retina(10 + (30 - size.width) / 2), 18) withFont:Font12Bold_];
+		[count_ drawInRect:CGRectMake(Retina(10 + (30 - size.width) / 2), 18, CGFLOAT_MAX, CGFLOAT_MAX) withAttributes:@{NSFontAttributeName: Font12Bold_, NSForegroundColorAttributeName: [UIColor colorWithCGColor:Folder_.color_]}];
 }
 
 @end

--- a/Source/UI/Sources/View Controllers/SourcesController.mm
+++ b/Source/UI/Sources/View Controllers/SourcesController.mm
@@ -84,7 +84,9 @@
     static NSString *cellIdentifier = @"SourceCell";
     
     SourceCell *cell = (SourceCell *) [tableView dequeueReusableCellWithIdentifier:cellIdentifier];
-    if (cell == nil) cell = [[[SourceCell alloc] initWithFrame:CGRectZero reuseIdentifier:cellIdentifier] autorelease];
+	//if (cell == nil) cell = [[[SourceCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:cellIdentifier] autorelease];
+	if (cell == nil) cell = [[[SourceCell alloc] initWithFrame:CGRectZero reuseIdentifier:cellIdentifier] autorelease];
+
     [cell setAccessoryType:UITableViewCellAccessoryDisclosureIndicator];
     
     Source *source([self sourceAtIndexPath:indexPath]);

--- a/Source/UI/Sources/Views/SourceCell.h
+++ b/Source/UI/Sources/Views/SourceCell.h
@@ -22,5 +22,6 @@
 - (void) setSource:(Source *)source;
 - (void) setFetch:(NSNumber *)fetch;
 - (void) setAllSource;
+- (SourceCell *) initWithFrame:(CGRect)frame reuseIdentifier:(NSString *)reuseIdentifier;
 
 @end

--- a/Source/UI/Sources/Views/SourceCell.mm
+++ b/Source/UI/Sources/Views/SourceCell.mm
@@ -125,14 +125,18 @@
     
     if (highlighted && kCFCoreFoundationVersionNumber < 800)
         UISetColor(White_);
-    
+	
     if (!highlighted)
         UISetColor(Black_);
-    [origin_ drawAtPoint:CGPointMake(52, 8) forWidth:(width - 49) withFont:Font18Bold_ lineBreakMode:NSLineBreakByTruncatingTail];
+	
+	NSMutableParagraphStyle *truncatingStyle = [[NSMutableParagraphStyle defaultParagraphStyle] mutableCopy];
+	[truncatingStyle setLineBreakMode:NSLineBreakByTruncatingTail];
+	
+	[origin_ drawInRect:CGRectMake(52, 8, width-49, CGFLOAT_MAX) withAttributes:@{NSFontAttributeName: Font18Bold_, NSParagraphStyleAttributeName: truncatingStyle}];
     
     if (!highlighted)
         UISetColor(Gray_);
-    [label_ drawAtPoint:CGPointMake(52, 29) forWidth:(width - 49) withFont:Font12_ lineBreakMode:NSLineBreakByTruncatingTail];
+	[label_ drawInRect:CGRectMake(52, 29, width-49, CGFLOAT_MAX) withAttributes:@{NSFontAttributeName: Font12_, NSParagraphStyleAttributeName: truncatingStyle, NSForegroundColorAttributeName: (!highlighted ? [UIColor colorWithCGColor:Gray_.color_]:[UIColor blackColor])}];
 }
 
 - (void) setFetch:(NSNumber *)fetch {

--- a/Source/UI/Stashing/View Controllers/StashController.mm
+++ b/Source/UI/Stashing/View Controllers/StashController.mm
@@ -15,7 +15,7 @@
     [view setAutoresizingMask:(UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight)];
     [self setView:view];
     
-    [view setBackgroundColor:[UIColor viewFlipsideBackgroundColor]];
+    [view setBackgroundColor:[UIColor blackColor]];
     
     spinner_ = [[[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleWhiteLarge] autorelease];
     CGRect spinrect = [spinner_ frame];

--- a/Source/Utilities/System/SystemHelpers.mm
+++ b/Source/Utilities/System/SystemHelpers.mm
@@ -30,7 +30,7 @@ NSString *CYHex(NSData *data, bool reverse) {
     
     size_t length([data length]);
     uint8_t bytes[length];
-    [data getBytes:bytes];
+    [data getBytes:bytes length:length];
     
     char string[length * 2 + 1];
     for (size_t i(0); i != length; ++i)


### PR DESCRIPTION
As said in title. The only warnings that remain are `system()` warnings, and a warning with `initWithFrame:reuseIdentifier:` in `SourceCell`. I have tried to solve this, but I keep getting blank source cells. I'll look further into this.

Also there are some other warnings to do with images + `libstdc++`, but I guess that's something someone else has to do, as I don't have access to the images and other.

(Addresses #12)