### PR TITLE
Basic author filtering

### DIFF
--- a/Source/Models/Packages/Package/Package.mm
+++ b/Source/Models/Packages/Package/Package.mm
@@ -898,6 +898,27 @@
     NSString *string;
     NSRange range;
     NSUInteger length;
+	
+	// If we are filtering for an author
+	if ([[(NSString*)query[0] lowercaseString] isEqualToString:@"author:"]) {
+		NSMutableArray *authorTerms = [query mutableCopy];
+		[authorTerms removeObjectAtIndex:0];
+		[self parse];
+		if ([self author] && [self author].name && ![[self author].name isEqualToString:@""]) {
+			for (NSString *term in authorTerms) {
+				range = [[self author].name rangeOfString:term options:MatchCompareOptions_];
+				if (range.location != NSNotFound)
+					rank_ -= 4 * 100000;
+			}
+		} else if ([self maintainer] && [self maintainer].name && ![[self maintainer].name isEqualToString:@""]) {
+			for (NSString *term in authorTerms) {
+				range = [[self maintainer].name rangeOfString:term options:MatchCompareOptions_];
+				if (range.location != NSNotFound)
+					rank_ -= 4 * 1000000;
+			}
+		}
+		return rank_ != 0;
+	}
     
     string = [self name];
     length = [string length];


### PR DESCRIPTION
Author Filtering:
- When searching for packages, you can add an author filter (currently only the filter allowed, no keywords in addition). Do this by adding "Author: " to the beginning of your query (include space). For performance reasons the filter is only run when the search button is pressed.
- This filters like a normal search query: It goes through every package and checks the author.

If this works out, we can "easily" add a "More by this author" button to the package page

Part 1/Possibly 2 of #36 